### PR TITLE
【求助】增加风速（音量）调节功能

### DIFF
--- a/src/components/RemoteControl.tsx
+++ b/src/components/RemoteControl.tsx
@@ -15,6 +15,8 @@ import { useAppDispatch, useAppSelector } from "../app/hooks";
 import {
   decreaseTemperature,
   increaseTemperature,
+  decreaseSpeed,
+  increaseSpeed,
   toggleMode,
   toggleStatus,
 } from "../features/ac/acSlice";
@@ -87,6 +89,9 @@ function playWorkSound() {
   ) as HTMLAudioElement;
   acWork.load();
   acWork.play();
+  /**
+   * ToDo: 需要实现设置初始音量以及按键触发后调节当前音量、并且在遥控器上画出来调节风速的按钮
+   */
 
   playWorkSoundTimeoutId = setTimeout(() => {
     playWorkSoundIntervalId = setInterval(() => {

--- a/src/features/ac/acSlice.ts
+++ b/src/features/ac/acSlice.ts
@@ -16,6 +16,10 @@ export interface AcState {
    * 温度
    */
   temperature: number;
+  /**
+   * 风速
+   */
+  speed: number;
 }
 
 const namespace = "ac-";
@@ -35,10 +39,13 @@ const initialState: AcState = {
   temperature:
     parseInt(localStorage.getItem(acItemKey.temperature) || "") ||
     defaultTemperature,
+  speed: (localStorage.getItem(acItemKey.speed) as AcMode) || 1.0,
 };
 
 const maxTemperature = 31;
 const minTemperature = 16;
+const maxSpeed = 1.0;
+const minSpeed = 0.0;
 
 export const acSlice = createSlice({
   name: "ac",
@@ -64,7 +71,7 @@ export const acSlice = createSlice({
      * 增加温度
      * @param state
      */
-    increment: (state) => {
+    incrementTemp: (state) => {
       state.temperature += 1;
       localStorage.setItem(acItemKey.temperature, state.temperature.toString());
     },
@@ -73,9 +80,26 @@ export const acSlice = createSlice({
      * 降低温度
      * @param state
      */
-    decrement: (state) => {
+    decrementTemp: (state) => {
       state.temperature -= 1;
       localStorage.setItem(acItemKey.temperature, state.temperature.toString());
+    },
+    /**
+     * 增加风速
+     * @param state
+     */
+    incrementSpeed: (state) => {
+      state.speed += 0.25;
+      localStorage.setItem(acItemKey.speed, state.speed.toString());
+    },
+
+    /**
+     * 降低风速
+     * @param state
+     */
+    decrementSpeed: (state) => {
+      state.speed -= 0.25;
+      localStorage.setItem(acItemKey.speed, state.speed.toString());
     },
 
     /**
@@ -101,11 +125,15 @@ export const acSlice = createSlice({
 });
 
 export const selectTemperature = (state: RootState) => state.ac.temperature;
+export const selectSpeed = (state: RootState) => state.ac.speed;
 
 export const {
   setTemperature,
-  increment,
-  decrement,
+  setSpeed,
+  incrementTemp,
+  decrementTemp,
+  incrementSpeed,
+  decrementSpeed,
   setMode,
   toggleStatus,
   setStatus,
@@ -118,7 +146,7 @@ export const {
 export const increaseTemperature = (): AppThunk => (dispatch, getState) => {
   const currentValue = selectTemperature(getState());
   if (currentValue < maxTemperature) {
-    dispatch(increment());
+    dispatch(incrementTemp());
   } else {
     dispatch(setMessage("已经是最大温度啦！"));
     dispatch(setOpen(true));
@@ -132,9 +160,37 @@ export const increaseTemperature = (): AppThunk => (dispatch, getState) => {
 export const decreaseTemperature = (): AppThunk => (dispatch, getState) => {
   const currentValue = selectTemperature(getState());
   if (currentValue > minTemperature) {
-    dispatch(decrement());
+    dispatch(decrementTemp());
   } else {
     dispatch(setMessage("已经是最小温度啦！"));
+    dispatch(setOpen(true));
+  }
+};
+
+/**
+ * 增加风速
+ * @returns
+ */
+export const increaseSpeed = (): AppThunk => (dispatch, getState) => {
+  const currentValue = selectSpeed(getState());
+  if (currentValue < maxSpeed) {
+    dispatch(incrementSpeed());
+  } else {
+    dispatch(setMessage("已经是最高风速啦！"));
+    dispatch(setOpen(true));
+  }
+};
+
+/**
+ * 降低风速
+ * @returns
+ */
+export const decreaseSpeed = (): AppThunk => (dispatch, getState) => {
+  const currentValue = selectSpeed(getState());
+  if (currentValue > minSpeed) {
+    dispatch(decrementSpeed());
+  } else {
+    dispatch(setMessage("已经是最低风速啦！"));
     dispatch(setOpen(true));
   }
 };


### PR DESCRIPTION
试图解决#26 #29

有一说一，纯小白……**所以后面的不会写了，就完全交给作者大大了吧……**

姑且写了/src/features/ac/acSlice.ts里的`acItemKey.speed`这个值，储存的是0.0~1.0的number；
并做出来了`decreaseSpeed`, ` increaseSpeed`两个函数，给前面的值加减0.25；
原先调节温度的函数进行了更名，`increment`-->`incrementTemp``decrement`-->`decrementTemp`。

根据[HTMLMediaElement.volume - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/volume)的说法，似乎调节风速的话，只需要给/src/components/RemoteControl.tsx里的`acWork.volume`赋值为前面的`acItemKey.speed`就可以，但是不知道怎么在两个文件之间传递值……

ToDo: 
- [ ] 实现设置初始音量
- [ ] 可选：把增值、减值的风速调节办法变成循环设置（在0.0 0.3 0.6 1.0共4个档位之间），这才是普通空调上的风速调节方式
- [ ] 实现按键触发后调节当前音量
- [ ] 在空调上画出当前风速显示
- [ ] 在遥控器上画出来调节风速的按钮
- [ ] 可选：变频空调：实现风速大小随函数变化，解决#30 #65

要实现变频的话，就不再是直接让`acWork.volume`等于`acItemKey.speed`，而是要做出一个函数算出来合适的风速`SetActualSpeed(acItemKey.actualTemp, acItemKey.speed){let acWork.volume=……}`，想一想如果前面的功能都实现了的话，这一步似乎不算复杂……
或者再退一步，变成伪变频空调，不需要`actualTemp`，简单地用计时器让音量从初始值慢慢变小就可以……