### PR TITLE
修复暗黑模式的 color palette

### DIFF
--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -30,11 +30,14 @@ export const ToggleModeBtn: React.FC = () => {
 };
 
 export const AppTheme: React.FC = (props) => {
+  const [mode, setMode] = React.useState<PaletteMode>("light");
   // https://developer.mozilla.org/zh-CN/docs/Web/CSS/@media/prefers-color-scheme
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
-  const preferredMode = prefersDarkMode ? "dark" : "light";
-
-  const [mode, setMode] = React.useState<PaletteMode>(preferredMode);
+  // Remount styles after React hydration
+  React.useEffect(() => {
+    const preferredMode = prefersDarkMode ? "dark" : "light";
+    setMode(preferredMode);
+  }, []);
 
   const colorMode = React.useMemo(
     () => ({


### PR DESCRIPTION
我也不知道这个 commit message 的格式是啥……@YunYouJun 大大帮我改一下吧

**Before:**

![image](https://user-images.githubusercontent.com/55398995/137269443-86cbbd6b-1eaf-4f42-a503-c92df4869a4b.png)

**After:**

![image](https://user-images.githubusercontent.com/55398995/137269497-58ef46bb-6992-4512-a910-1b88c7822e78.png)

我不是很能解释这是为什么，有可能是因为 React hydration 的时候没有根据浏览器的`prefer-color-scheme`重新挂载palette……？

除了这个贡献，不知道作者大大考不考虑这些建议：

- 删除 CRA 自带的 App.test.tsx 这些文件，因为看起来没有用上；
- 把 lockfile 也一起 commit 了，对大家同步 dependency 版本和 CI 的时候快速 install 都有好处：https://classic.yarnpkg.com/blog/2016/11/24/lockfiles-for-all/